### PR TITLE
fix: restrict service worker caching and phone formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,8 +224,8 @@ async function setWakeLock(on){
 
   function pretty(tel){
     const d=tel.replace(/\D/g,'');
-    if(d.length===11 && d.startsWith('1')){const n=d.slice(1); return `( ${n.slice(0,3)} ) ${n.slice(3,6)}-${n.slice(6)}`;}
-    if(d.length===10){return `( ${d.slice(0,3)} ) ${d.slice(3,6)}-${d.slice(6)}`;}
+    if(d.length===11 && d.startsWith('1')){const n=d.slice(1); return `(${n.slice(0,3)}) ${n.slice(3,6)}-${n.slice(6)}`;}
+    if(d.length===10){return `(${d.slice(0,3)}) ${d.slice(3,6)}-${d.slice(6)}`;}
     return tel;
   }
 


### PR DESCRIPTION
## Summary
- avoid caching cross-origin fetches in service worker
- skip caching unsuccessful responses
- remove stray spaces when formatting US phone numbers

## Testing
- `node --check sw.js`
- `node - <<'NODE'` test for pretty()


------
https://chatgpt.com/codex/tasks/task_e_68adfa3776b48330869b2c4670680018